### PR TITLE
Allow log methods to receive block

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,11 @@ To send logs, use "log" method. Default log level is "INFO"
     logger.log('This is my first log')
     => "Saved"  # Saved to buffer. Ready to be flushed automatically
 
+Optionally you can use a block to do so
+
+    logger.log { 'This is my second log' }
+    => "Saved"
+
 Log a message with particular metadata, level, appname, environment (one-time)
 
     logger.log('This is warn message', {:meta => {:meta => "data"}, :level => "WARN", :app => "awesome", :env => "DEVELOPMENT"})
@@ -83,6 +88,7 @@ Log a message with a particular level easily
 
     logger.warn('This is a warning message')
     logger.fatal('This is a fatal message')
+    logger.debug { 'This is a debug message' }
 
 
 Hostname and app name cannot be more than 80 characters.

--- a/lib/logdna.rb
+++ b/lib/logdna.rb
@@ -83,7 +83,8 @@ module Logdna
 
     def log(msg=nil, opts={})
       loggerExist?
-      @response = @@client.buffer(msg, default_opts.merge(opts).merge({
+      message = yield if msg.nil? && block_given?
+      @response = @@client.buffer(message, default_opts.merge(opts).merge({
             timestamp: (Time.now.to_f * 1000).to_i
         }))
       'Saved'
@@ -92,10 +93,10 @@ module Logdna
     Resources::LOG_LEVELS.each do |lvl|
       name = lvl.downcase
 
-      define_method name do |msg=nil, opts={}|
+      define_method name do |msg=nil, opts={}, &block|
         self.log(msg, opts.merge({
           level: lvl,
-        }))
+        }), &block)
       end
 
       define_method "#{name}?" do

--- a/lib/logdna/version.rb
+++ b/lib/logdna/version.rb
@@ -1,3 +1,3 @@
 module LogDNA
-  VERSION = '1.1.1'.freeze
+  VERSION = '1.2.0'.freeze
 end


### PR DESCRIPTION
[As the Ruby logger does](https://ruby-doc.org/stdlib-2.5.0/libdoc/logger/rdoc/Logger.html), logging methods should be able to receive a block with the message, that allows to delay the evaluation of complex messages until the message is actually logged.

Also by doing this, this gem will be out of the box compatible with Rails, in the sense that it will work with the Rack middleware responsable of logging every request https://github.com/rails/rails/blob/ee35b79d4cff24b960be54c3f5c4f46627c069fe/railties/lib/rails/rack/logger.rb#L37
