### PR TITLE
fix log methods ignore calls with string msg argument incorrectly

### DIFF
--- a/lib/logdna.rb
+++ b/lib/logdna.rb
@@ -83,6 +83,7 @@ module Logdna
 
     def log(msg=nil, opts={})
       loggerExist?
+      message = msg
       message = yield if msg.nil? && block_given?
       @response = @@client.buffer(message, default_opts.merge(opts).merge({
             timestamp: (Time.now.to_f * 1000).to_i

--- a/lib/logdna/version.rb
+++ b/lib/logdna/version.rb
@@ -1,3 +1,3 @@
 module LogDNA
-  VERSION = '1.2.0'.freeze
+  VERSION = '1.2.1'.freeze
 end


### PR DESCRIPTION
Logging calls with string argument like `logger.info('hello world')` is broken since pull request !3 is accepted. This pull request addresses and fixes the issue.