### PR TITLE
Update logger initialization to accept endpoint as a value but default to primary entrypoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,8 @@ Options are optional variables that may contain hostname, app name, mac address,
         :app => myAppName,
         :level => "INFO",    # LOG_LEVELS = ['TRACE', 'DEBUG', 'INFO', 'WARN', 'ERROR', 'FATAL'] or your customized log level
         :env => "PRODUCTION",
-        :meta => {:once => {:first => "nested1", :another => "nested2"}}
+        :meta => {:once => {:first => "nested1", :another => "nested2"}},
+        :endpoint => "https://fqdn/logs/ingest"
     }
 
 To send logs, use "log" method. Default log level is "INFO"
@@ -99,7 +100,6 @@ Hostname and app name cannot be more than 80 characters.
 1. This logger assumes that you pass in json formatted data
 2. This logger is a singleton (do not create mutiple instances of the logger) even though the singleton structure is not strongly enforced. 
 
-
 # API
 
 ## Logdna::Ruby.new(ingestion_key, options = {})
@@ -115,6 +115,7 @@ Instantiates a new instance of the class it is called on. ingestion_key is requi
 |{ :level => Log level } | 'INFO' |
 |{ :env => STAGING, PRODUCTION .. etc} | Nil |
 |{ :meta => metadata} | Nil |
+|{ :endpoint => LogDNA Ingestion URI | 'https://logs.logdna.com/logs/ingest' |
 |{ :flushtime => Log flush interval in seconds } | 0.25 seconds |
 |{ :flushbyte => Log flush upper limit in bytes } | 500000 bytes ~= 0.5 megabytes |
 

--- a/lib/logdna.rb
+++ b/lib/logdna.rb
@@ -21,8 +21,8 @@ module Logdna
       @env = opts[:env]
       @meta = opts[:meta]
       @@client = nil unless defined? @@client
-      @endpoint = opts[:endpoint] || Resources::ENDPOINT
-
+      
+      endpoint = opts[:endpoint] || Resources::ENDPOINT
       hostname = opts[:hostname] || Socket.gethostname
       ip =  opts.key?(:ip) ? "&ip=#{opts[:ip]}" : ''
       mac = opts.key?(:mac) ? "&mac=#{opts[:mac]}" : ''

--- a/lib/logdna.rb
+++ b/lib/logdna.rb
@@ -21,11 +21,12 @@ module Logdna
       @env = opts[:env]
       @meta = opts[:meta]
       @@client = nil unless defined? @@client
+      @endpoint = opts[:endpoint] || Resources::ENDPOINT
 
       hostname = opts[:hostname] || Socket.gethostname
       ip =  opts.key?(:ip) ? "&ip=#{opts[:ip]}" : ''
       mac = opts.key?(:mac) ? "&mac=#{opts[:mac]}" : ''
-      url = "#{Resources::ENDPOINT}?hostname=#{hostname}#{mac}#{ip}"
+      url = "#{endpoint}?hostname=#{hostname}#{mac}#{ip}"
 
       begin
         if (hostname.size > Resources::MAX_INPUT_LENGTH || @app.size > Resources::MAX_INPUT_LENGTH )

--- a/lib/logdna/version.rb
+++ b/lib/logdna/version.rb
@@ -1,3 +1,3 @@
 module LogDNA
-  VERSION = '1.2.0'.freeze
+  VERSION = '1.3.0'.freeze
 end


### PR DESCRIPTION
To use this updated version an example might be:

```
options = {
  'endpoint' => 'https://us-south.logging.cloud.ibm.com/logs/ingest'
}

logger = Logdna::Ruby.new(your_api_key, options)
```

Although for ease of use changing it so that it only brings in the fqdn, and the rest is in code would be good.