### PR TITLE
In CircleCI, when linting with Rubocop, don't autocorrect

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,7 +16,7 @@ jobs:
     steps:
       - checkout
       - run: bundle install
-      - run: rubocop -c .rubocop.yml -a
+      - run: rubocop -c .rubocop.yml
   build:
     docker:
       - image: circleci/ruby:2.6.5


### PR DESCRIPTION
We're calling `rubocop` with `-a` which autocorrects lint errors (that can be autocorrected). That's not what we want to do - we want to report them.

Before: master passes CircleCI

After: it fails due to failing lint checks. The lint checks were failing before, but CircleCI was passing because they were autocorrected.