### PR TITLE
Fix Rubocop errors around MutableConstant

### DIFF
--- a/lib/logdna/resources.rb
+++ b/lib/logdna/resources.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
 module Resources
-  LOG_LEVELS = %w[DEBUG INFO WARN ERROR FATAL TRACE]
-  DEFAULT_REQUEST_HEADER = { "Content-Type" => "application/json; charset=UTF-8" }
+  LOG_LEVELS = %w[DEBUG INFO WARN ERROR FATAL TRACE].freeze
+  DEFAULT_REQUEST_HEADER = { "Content-Type" => "application/json; charset=UTF-8" }.freeze
   DEFAULT_REQUEST_TIMEOUT = 180_000
   MS_IN_A_DAY = 86_400_000
   MAX_REQUEST_TIMEOUT = 300_000
@@ -12,6 +12,6 @@ module Resources
   FLUSH_INTERVAL = 0.25
   FLUSH_BYTE_LIMIT = 500_000
   ENDPOINT = "https://logs.logdna.com/logs/ingest"
-  MAC_ADDR_CHECK = /^([0-9a-fA-F][0-9a-fA-F]:){5}([0-9a-fA-F][0-9a-fA-F])$/
-  IP_ADDR_CHECK = /^(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$/
+  MAC_ADDR_CHECK = /^([0-9a-fA-F][0-9a-fA-F]:){5}([0-9a-fA-F][0-9a-fA-F])$/.freeze
+  IP_ADDR_CHECK = /^(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$/.freeze
 end


### PR DESCRIPTION
2 things here:
1/ Want to show how to do a stacked PR on dependent branches
2/ Fixing the lint errors. The errors are legit - while we are freezing all string constants, we're not freezing the objects containing the strings.

Before: `rubocop -c .rubocop.yml` generates errors
After: `rubocop -c .rubocop.yml` generates no errors