### PR TITLE
Remove the condition for scheduling the flush and call lambda.

### DIFF
--- a/lib/logdna/client.rb
+++ b/lib/logdna/client.rb
@@ -49,7 +49,7 @@ module Logdna
         sleep(@exception_flag ? @retry_timeout : @flush_interval)
         flush if @flush_scheduled
       }
-      thread = Thread.new { start_timer }
+      thread = Thread.new { start_timer.call }
       thread.join
     end
 
@@ -63,7 +63,7 @@ module Logdna
         @lock.unlock
 
         flush if @flush_limit <= @buffer_byte_size
-        schedule_flush unless @flush_scheduled
+        schedule_flush
       else
         @side_message_lock.synchronize do
           @side_messages.push(process_message(msg, opts))

--- a/lib/logdna/client.rb
+++ b/lib/logdna/client.rb
@@ -62,8 +62,11 @@ module Logdna
         @flush_scheduled = true
         @lock.unlock
 
-        flush if @flush_limit <= @buffer_byte_size
-        schedule_flush
+        if @flush_limit <= @buffer_byte_size
+          flush
+        else
+          schedule_flush
+        end
       else
         @side_message_lock.synchronize do
           @side_messages.push(process_message(msg, opts))


### PR DESCRIPTION
I was assigning @flush_scheduled to true and did not call the scheduler if the flag was true. I removed this condition. And I also did not call lambda.

Jhonny noticed that he did not see the logs if he used the lib without options. The reason is that, he defines a small number for his buffer limit in the options and the logs got sent because the condition on the line 65 was satisfied. However, when he tried to log without passing the options, this condition was not satisfies because the default buffer size limit is larger than the string he attempted to send. 

I tested it by initializing the logger without options 
and setting options like this: 
options = {
    :hostname => 'rubyTestHost',
    :ip =>  '75.10.4.81',
    :mac => '00:00:00:a1:2b:cc',
    :app => 'rubyApplication',
    :level => "INFO",
    :env => "PRODUCTION",
    :endpoint => "https://logs.logdna.com/logs/ingest",
    :flush_interval => 10,
    :flush_size => 50000,
    :retry_timeout => 60
}

$logger = Logdna::Ruby.new("73523d0836905067b4940f4a718940f9", options)