### PR TITLE
update autopublish mechanism

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,11 +33,11 @@ jobs:
               echo "  PKG_VERSION: v${PKG_VERSION}"
               exit 1
             fi
-      - run: gem build logdna.gemspec
+      - run: gem build logdna.gemspec -o logdna.gem
       - persist_to_workspace:
           root: .
           paths:
-            - ./logdna-*.gem
+            - ./logdna.gem
   release:
     docker:
       - image: circleci/golang:1.12
@@ -57,7 +57,7 @@ jobs:
       - persist_to_workspace:
           root: .
           paths:
-            - ./logdna-*.gem
+            - ./logdna.gem
   approve:
     machine: true
     steps:
@@ -66,7 +66,7 @@ jobs:
       - persist_to_workspace:
           root: .
           paths:
-            - ./logdna-*.gem
+            - ./logdna.gem
   publish:
     docker:
       - image: circleci/ruby:2.6.5
@@ -76,11 +76,13 @@ jobs:
       - run:
           name: Setup gem credentials
           command: |
-            mkdir -p ~/.gem/
-            echo "---\n:rubygems_api_key: ${RUBYGEMS_API_KEY}" >> ~/.gem/credentials
-            chmod 600 ~/.gem/credentials
-      - run: gem signin
-      - run: gem push *.gem
+            mkdir -p ~/.gem
+            cat \<<EOF > ~/.gem/credentials
+            ---
+            :rubygems_api_key: ${RUBYGEMS_API_KEY}
+            EOF
+            chmod 0600 ~/.gem/credentials
+      - run: gem push logdna.gem
 workflows:
   update:
     jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,11 +33,11 @@ jobs:
               echo "  PKG_VERSION: v${PKG_VERSION}"
               exit 1
             fi
-      - run: gem build logdna.gemspec -o logdna.gem
+      - run: gem build logdna.gemspec
       - persist_to_workspace:
           root: .
           paths:
-            - ./logdna.gem
+            - ./logdna-*.gem
   release:
     docker:
       - image: circleci/golang:1.12
@@ -57,7 +57,7 @@ jobs:
       - persist_to_workspace:
           root: .
           paths:
-            - ./logdna.gem
+            - ./logdna-*.gem
   approve:
     machine: true
     steps:
@@ -66,7 +66,7 @@ jobs:
       - persist_to_workspace:
           root: .
           paths:
-            - ./logdna.gem
+            - ./logdna-*.gem
   publish:
     docker:
       - image: circleci/ruby:2.6.5
@@ -82,7 +82,7 @@ jobs:
             :rubygems_api_key: ${RUBYGEMS_API_KEY}
             EOF
             chmod 0600 ~/.gem/credentials
-      - run: gem push logdna.gem
+      - run: gem push *.gem
 workflows:
   update:
     jobs:

--- a/logdna.gemspec
+++ b/logdna.gemspec
@@ -8,7 +8,7 @@ Gem::Specification.new do |spec|
   spec.name = "logdna"
   spec.version = version
   spec.authors       = "Gun Woo Choi, Derek Zhou, Vilya Levitskiy, Muaz Siddiqui"
-  spec.email         = "support@logdna.com"
+  spec.email         = "apps+rubygems@logdna.com"
   spec.summary       = "LogDNA Ruby logger"
   spec.homepage      = "https://github.com/logdna/ruby"
   spec.license       = "MIT"


### PR DESCRIPTION
This is for automating publishment of the `logdna.gem` to `RubyGems` referring to [this](https://github.com/ryym/opsup/blob/master/.circleci/config.yml#L57-L67) and since the email used for our `RubyGems` account is `apps+rubygems@logdna.com`, I had to update it inside `gemspec` too.