### PR TITLE
Drop blocking thread.join call

### DIFF
--- a/lib/logdna/client.rb
+++ b/lib/logdna/client.rb
@@ -49,7 +49,7 @@ module Logdna
         sleep(@exception_flag ? @retry_timeout : @flush_interval)
         flush if @flush_scheduled
       }
-      thread = Thread.new { start_timer.call }
+      Thread.new { start_timer.call }
     end
 
     def write_to_buffer(msg, opts)

--- a/lib/logdna/client.rb
+++ b/lib/logdna/client.rb
@@ -50,7 +50,6 @@ module Logdna
         flush if @flush_scheduled
       }
       thread = Thread.new { start_timer.call }
-      thread.join
     end
 
     def write_to_buffer(msg, opts)


### PR DESCRIPTION
In the [schedule_flush](https://github.com/logdna/ruby/blob/master/lib/logdna/client.rb#L47) method, a Thread is created (I assume) to prevent blocking by handling the scheduling logic asynchronously in an external thread.

Unfortunately, the call to `thread.join` has the side effect of blocking execution until the Thread is done sleeping and completed its call to `flush`. 

Within a Rail application, this has the side effect of increasing the response time of every request by `(calls to logger) * @flush_interval`. (Indeed our response times increased nearly 30% the week we upgraded this gem.)

It's important to note that by _not_ calling `thread.join` it's possible the program may exit without executing the contents of the thread. However, in this case it's simply scheduling a call to `flush`, where `flush` is already called explicitly on `at_exit` so the risk of buffer data loss is quite low considering the performance benefits.
