### PR TITLE
Put flush method call into separate threads

### DIFF
--- a/lib/logdna/client.rb
+++ b/lib/logdna/client.rb
@@ -61,7 +61,6 @@ module Logdna
 
         if @flush_limit <= @buffer_byte_size
           Thread.new { flush }
-          # flush
         else
           @flush_scheduled = true
           schedule_flush

--- a/lib/logdna/client.rb
+++ b/lib/logdna/client.rb
@@ -6,6 +6,7 @@ require "json"
 require "concurrent"
 require "date"
 
+
 module Logdna
   class Client
     def initialize(request, uri, opts)
@@ -60,9 +61,8 @@ module Logdna
         @buffer_byte_size += new_message_size
         @flush_scheduled = true
         @lock.unlock
-
         if @flush_limit <= @buffer_byte_size
-          flush
+          Thread.new { flush }
         else
           schedule_flush
         end
@@ -131,7 +131,7 @@ module Logdna
     end
 
     def exitout
-      flush
+      Thread.new { flush }
       @internal_logger.debug("Exiting LogDNA logger: Logging remaining messages")
     end
   end

--- a/lib/logdna/client.rb
+++ b/lib/logdna/client.rb
@@ -6,7 +6,6 @@ require "json"
 require "concurrent"
 require "date"
 
-
 module Logdna
   class Client
     def initialize(request, uri, opts)
@@ -61,6 +60,7 @@ module Logdna
         @buffer_byte_size += new_message_size
         @flush_scheduled = true
         @lock.unlock
+
         if @flush_limit <= @buffer_byte_size
           Thread.new { flush }
         else

--- a/test_server.rb
+++ b/test_server.rb
@@ -6,25 +6,6 @@ class TestServer
   def start_server(port)
     TCPServer.new(port)
   end
-  # def start_server(port)
-  #   server = TCPServer.new(port)
-  #   puts server
-  #   data = ""
-  #
-  #   Thread.start(server.accept) { |client|
-  #     headers = {}
-  #     while line = client.gets.split(" ", 2)
-  #       break if line[0] == ""
-  #
-  #       headers[line[0].chop] = line[1].strip
-  #     end
-  #     data = client.read(headers["Content-Length"].to_i)
-  #     client.puts("HTTP/1.1 200 OK")
-  #     client.close
-  #   }.join
-  #
-  #   eval(data)
-  # end
 
   def accept_logs_and_respond(server, res)
     data = ""
@@ -41,25 +22,6 @@ class TestServer
       client.close
     }.join
 
-    eval(data)
-  end
-
-  def return_not_found_res(port)
-
-    server = TCPServer.new(port)
-    data = ""
-    data += accept_logs_and_respond(server, data, "HTTP/1.1 404 Not Found")
-
-    # data += accept_logs_and_respond(server, data, "HTTP/1.1 200 OK")
-    {:data => eval(data), :server => server}
-  end
-
-  def tt(server)
-    data = ""
-    data += accept_logs_and_respond(server, data, "HTTP/1.1 404 Not Found")
-    puts ("FROM")
-    puts data
-    # data += accept_logs_and_respond(server, data, "HTTP/1.1 200 OK")
     eval(data)
   end
 end

--- a/test_server.rb
+++ b/test_server.rb
@@ -4,10 +4,30 @@ require "socket"
 
 class TestServer
   def start_server(port)
-    server = TCPServer.new(port)
-    puts server
-    data = ""
+    TCPServer.new(port)
+  end
+  # def start_server(port)
+  #   server = TCPServer.new(port)
+  #   puts server
+  #   data = ""
+  #
+  #   Thread.start(server.accept) { |client|
+  #     headers = {}
+  #     while line = client.gets.split(" ", 2)
+  #       break if line[0] == ""
+  #
+  #       headers[line[0].chop] = line[1].strip
+  #     end
+  #     data = client.read(headers["Content-Length"].to_i)
+  #     client.puts("HTTP/1.1 200 OK")
+  #     client.close
+  #   }.join
+  #
+  #   eval(data)
+  # end
 
+  def accept_logs_and_respond(server, res)
+    data = ""
     Thread.start(server.accept) { |client|
       headers = {}
       while line = client.gets.split(" ", 2)
@@ -15,36 +35,31 @@ class TestServer
 
         headers[line[0].chop] = line[1].strip
       end
-      data = client.read(headers["Content-Length"].to_i)
-      client.puts("HTTP/1.1 200 OK")
+
+      data += client.read(headers["Content-Length"].to_i)
+      client.puts(res)
       client.close
     }.join
 
     eval(data)
   end
 
-  def accept_logs_and_respond(server, data, res)
-    Thread.start(server.accept) { |client|
-      headers = {}
-      while line = client.gets.split(" ", 2)
-        break if line[0] == ""
-
-        headers[line[0].chop] = line[1].strip
-      end
-      data += client.read(headers["Content-Length"].to_i)
-      client.puts(res)
-      client.close
-    }.join
-
-    data
-  end
-
   def return_not_found_res(port)
+
     server = TCPServer.new(port)
     data = ""
-    accept_logs_and_respond(server, data, "HTTP/1.1 404 Not Found")
-    data += accept_logs_and_respond(server, data, "HTTP/1.1 200 OK")
+    data += accept_logs_and_respond(server, data, "HTTP/1.1 404 Not Found")
 
+    # data += accept_logs_and_respond(server, data, "HTTP/1.1 200 OK")
+    {:data => eval(data), :server => server}
+  end
+
+  def tt(server)
+    data = ""
+    data += accept_logs_and_respond(server, data, "HTTP/1.1 404 Not Found")
+    puts ("FROM")
+    puts data
+    # data += accept_logs_and_respond(server, data, "HTTP/1.1 200 OK")
     eval(data)
   end
 end

--- a/tests.rb
+++ b/tests.rb
@@ -32,9 +32,9 @@ class TestLogDNARuby < Minitest::Test
     end
 
     server_thread = Thread.start do
-      serverGenerator = TestServer.new
-      server = serverGenerator.start_server(port)
-      recieved_data = serverGenerator.accept_logs_and_respond(server, "HTTP/1.1 200 OK")
+      server_generator = TestServer.new
+      server = server_generator.start_server(port)
+      recieved_data = server_generator.accept_logs_and_respond(server, "HTTP/1.1 200 OK")
 
       assert_equal(recieved_data[:ls][0][:line], LOG_LINE)
       assert_equal(recieved_data[:ls][0][:app], options[:app])
@@ -56,12 +56,12 @@ class TestLogDNARuby < Minitest::Test
     end
 
     server_thread = Thread.start do
-      serverGenerator = TestServer.new
-      server = serverGenerator.start_server(port)
-      serverGenerator.accept_logs_and_respond(server, "HTTP/1.1 404 Not Found")
+      server_generator = TestServer.new
+      server = server_generator.start_server(port)
+      server_generator.accept_logs_and_respond(server, "HTTP/1.1 404 Not Found")
       # make a second request
       logger.send(level, second_line)
-      recieved_data = serverGenerator.accept_logs_and_respond(server, "HTTP/1.1 202 Not Found")
+      recieved_data = server_generator.accept_logs_and_respond(server, "HTTP/1.1 202 Not Found")
 
       # should contain lines from both requests
       assert_equal(recieved_data[:ls].size, 2)

--- a/tests.rb
+++ b/tests.rb
@@ -47,13 +47,12 @@ class TestLogDNARuby < Minitest::Test
   end
 
   # Should retry to connect and preserve the failed line
-  def fatal_method_not_found(level, port, expected_level)
+  def retry_test(level, port, _expected_level)
     second_line = " second line"
     options = get_options(port)
+
     logger = Logdna::Ruby.new("pp", options)
-    logdna_thread = Thread.start do
-      logger.send(level, LOG_LINE)
-    end
+    logger.send(level, LOG_LINE)
 
     server_thread = Thread.start do
       server_generator = TestServer.new
@@ -68,13 +67,8 @@ class TestLogDNARuby < Minitest::Test
       # The order of recieved lines is unpredictable.
       assert_includes([recieved_data[:ls][0][:line], recieved_data[:ls][1][:line]], LOG_LINE)
       assert_includes([recieved_data[:ls][0][:line], recieved_data[:ls][1][:line]], second_line)
-      ####
-      assert_equal(recieved_data[:ls][0][:app], options[:app])
-      assert_equal(recieved_data[:ls][0][:level], expected_level)
-      assert_equal(recieved_data[:ls][0][:env], options[:env])
     end
 
-    logdna_thread.join
     server_thread.join
   end
 
@@ -83,6 +77,6 @@ class TestLogDNARuby < Minitest::Test
     log_level_test("info", 2001, "INFO")
     log_level_test("fatal", 2002, "FATAL")
     log_level_test("debug", 2003, "DEBUG")
-    fatal_method_not_found("fatal", 2004, "FATAL")
+    retry_test("fatal", 2004, "FATAL")
   end
 end

--- a/tests.rb
+++ b/tests.rb
@@ -33,7 +33,6 @@ class TestLogDNARuby < Minitest::Test
 
     server_thread = Thread.start do
       serverGenerator = TestServer.new
-      # recieved_data = server.start_server(port)
       server = serverGenerator.start_server(port)
       recieved_data = serverGenerator.accept_logs_and_respond(server, "HTTP/1.1 200 OK")
 


### PR DESCRIPTION
-all flush calls are put to their own threads
- replaced one of the @lock.try calls with synchronize block
- cleaned the test code 

I tried to compare performance of my test rails application with the master branch and these changes. I did not see any changes in  the time lapse before the log was send and after but  the server itself was starting and ending quicker.` 