### PR TITLE
Unify log-level helper methods behavior.

### DIFF
--- a/lib/logdna/resources.rb
+++ b/lib/logdna/resources.rb
@@ -1,7 +1,9 @@
 # frozen_string_literal: true
-
+require 'logger'
 module Resources
+  TRACE = Logger::Severity::UNKNOWN
   LOG_LEVELS = %w[DEBUG INFO WARN ERROR FATAL TRACE].freeze
+
   DEFAULT_REQUEST_HEADER = { "Content-Type" => "application/json; charset=UTF-8" }.freeze
   DEFAULT_REQUEST_TIMEOUT = 180_000
   MS_IN_A_DAY = 86_400_000

--- a/test/tests.rb
+++ b/test/tests.rb
@@ -80,4 +80,43 @@ class TestLogDNARuby < Minitest::Test
     log_level_test("debug", 2003, "DEBUG")
     retry_test("fatal", 2004, "FATAL")
   end
+
+  def test_log_level_helper_methods
+    debug_level_test
+    warn_level_test
+    trace_level_test
+  end
+
+  def debug_level_test
+    logger = Logdna::Ruby.new("pp", level: "DEBUG")
+
+    assert_equal(logger.debug?, true, "#debug? for 'DEBUG' level should be true")
+    assert_equal(logger.info?,  true,  "#info? for 'DEBUG' level should be true")
+    assert_equal(logger.warn?,  true,  "#warn? for 'DEBUG' level should be true")
+    assert_equal(logger.error?, true, "#error? for 'DEBUG' level should be true")
+    assert_equal(logger.fatal?, true, "#fatal? for 'DEBUG' level should be true")
+    assert_equal(logger.trace?, true, "#trace? for 'DEBUG' level should be true")
+  end
+
+  def warn_level_test
+    logger = Logdna::Ruby.new("pp", level: "WARN")
+
+    assert_equal(logger.debug?, false, "#debug? for 'WARN' level should be false")
+    assert_equal(logger.info?,  false,  "#info? for 'WARN' level should be false")
+    assert_equal(logger.warn?,  true,   "#warn? for 'WARN' level should be true")
+    assert_equal(logger.error?, true,  "#error? for 'WARN' level should be true")
+    assert_equal(logger.fatal?, true,  "#fatal? for 'WARN' level should be true")
+    assert_equal(logger.trace?, true,  "#trace? for 'WARN' level should be true")
+  end
+
+  def trace_level_test
+    logger = Logdna::Ruby.new("pp", level: "TRACE")
+
+    assert_equal(logger.debug?, false, "#debug? for 'TRACE' level should be false")
+    assert_equal(logger.info?,  false,  "#info? for 'TRACE' level should be false")
+    assert_equal(logger.warn?,  false,  "#warn? for 'TRACE' level should be false")
+    assert_equal(logger.error?, false, "#error? for 'TRACE' level should be false")
+    assert_equal(logger.fatal?, false, "#fatal? for 'TRACE' level should be false")
+    assert_equal(logger.trace?, true,  "#trace? for 'TRACE' level should be true")
+  end
 end


### PR DESCRIPTION
`Logdna::Ruby` logger overrides its parent `Logger` class behavior for helper methods such as `#info?`.
 It also defines a 5th level `TRACE` that seems to be the same as `Loger::Severity::UNKNOWN`.

So I've decided to rewrite the overridden methods because it makes `Logdna::Ruby` logger incompatible with, for example, Rails. For example `ActionController::LogSubscriber` https://github.com/rails/rails/blob/v5.2.1/actionpack/lib/action_controller/log_subscriber.rb#L8 is only logging responses when severity is set to below `INFO`. But the `Logdna::Ruby#info?` returns false even if the log level has been set to `DEBUG`.
